### PR TITLE
#7527 performance benchmark - verifying performance impact of inferred query parameter types

### DIFF
--- a/tests/Doctrine/Performance/EntityManagerFactory.php
+++ b/tests/Doctrine/Performance/EntityManagerFactory.php
@@ -2,6 +2,10 @@
 
 namespace Doctrine\Performance;
 
+use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Cache\ArrayStatement;
+use Doctrine\DBAL\Cache\QueryCacheProfile;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
@@ -20,7 +24,7 @@ final class EntityManagerFactory
         $config->setAutoGenerateProxyClasses(ProxyFactory::AUTOGENERATE_EVAL);
         $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([
             realpath(__DIR__ . '/Models/Cache'),
-            realpath(__DIR__ . '/Models/GeoNames')
+            realpath(__DIR__ . '/Models/GeoNames'),
         ], true));
 
         $entityManager = EntityManager::create(
@@ -35,5 +39,30 @@ final class EntityManagerFactory
             ->createSchema(array_map([$entityManager, 'getClassMetadata'], $schemaClassNames));
 
         return $entityManager;
+    }
+
+    public static function makeEntityManagerWithNoResultsConnection() : EntityManagerInterface
+    {
+        $config = new Configuration();
+
+        $config->setProxyDir(__DIR__ . '/../Tests/Proxies');
+        $config->setProxyNamespace('Doctrine\Tests\Proxies');
+        $config->setAutoGenerateProxyClasses(ProxyFactory::AUTOGENERATE_EVAL);
+        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([
+            realpath(__DIR__ . '/Models/Cache'),
+            realpath(__DIR__ . '/Models/Generic'),
+            realpath(__DIR__ . '/Models/GeoNames'),
+        ], true));
+
+        // A connection that doesn't really do anything
+        $connection = new class ([], new Driver(), null, new EventManager()) extends Connection
+        {
+            public function executeQuery($query, array $params = [], $types = [], QueryCacheProfile $qcp = null)
+            {
+                return new ArrayStatement([]);
+            }
+        };
+
+        return EntityManager::create($connection, $config);
     }
 }

--- a/tests/Doctrine/Performance/Query/QueryBoundParameterProcessingBench.php
+++ b/tests/Doctrine/Performance/Query/QueryBoundParameterProcessingBench.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Performance\Query;
+
+use DateTime;
+use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\ORM\Query;
+use Doctrine\Performance\EntityManagerFactory;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use function range;
+
+/**
+ * @BeforeMethods({"init"})
+ */
+final class QueryBoundParameterProcessingBench
+{
+    /** @var Query */
+    private $parsedQueryWithInferredParameterType;
+
+    /** @var Query */
+    private $parsedQueryWithDeclaredParameterType;
+
+    public function init() : void
+    {
+        $entityManager = EntityManagerFactory::makeEntityManagerWithNoResultsConnection();
+
+        // Note: binding a lot of parameters because DQL operations are noisy due to hydrators and other components
+        //       kicking in, so we make the parameter operations more noticeable.
+        $dql = <<<'DQL'
+SELECT e
+FROM Doctrine\Tests\Models\Generic\DateTimeModel e
+WHERE
+    e.datetime = :parameter1
+    OR
+    e.datetime = :parameter2
+    OR
+    e.datetime = :parameter3
+    OR
+    e.datetime = :parameter4
+    OR
+    e.datetime = :parameter5
+    OR
+    e.datetime = :parameter6
+    OR
+    e.datetime = :parameter7
+    OR
+    e.datetime = :parameter8
+    OR
+    e.datetime = :parameter9
+    OR
+    e.datetime = :parameter10
+DQL;
+
+        $this->parsedQueryWithInferredParameterType = $entityManager->createQuery($dql);
+        $this->parsedQueryWithDeclaredParameterType = $entityManager->createQuery($dql);
+
+        foreach (range(1, 10) as $index) {
+            $this->parsedQueryWithInferredParameterType->setParameter('parameter' . $index, new DateTime());
+            $this->parsedQueryWithDeclaredParameterType->setParameter('parameter' . $index, new DateTime(), DateTimeType::DATETIME);
+        }
+
+        // Force parsing upfront - we don't benchmark that bit in this scenario
+        $this->parsedQueryWithInferredParameterType->getSQL();
+        $this->parsedQueryWithDeclaredParameterType->getSQL();
+    }
+
+    public function benchExecuteParsedQueryWithInferredParameterType() : void
+    {
+        $this->parsedQueryWithInferredParameterType->execute();
+    }
+
+    public function benchExecuteParsedQueryWithDeclaredParameterType() : void
+    {
+        $this->parsedQueryWithDeclaredParameterType->execute();
+    }
+}
+


### PR DESCRIPTION
As an example result:

```
./phpbench.phar run tests/Doctrine/Performance/Query --iterations=50 --revs=50 --report=aggregate
PhpBench 0.15-dev (dcbe193). Running benchmarks.
Using configuration file: /home/ocramius/Documents/doctrine/doctrine2/phpbench.json

\Doctrine\Performance\Query\QueryBoundParameterProcessingBench

    benchExecuteParsedQueryWithInferredParameterTypeI49 P0 	[μ Mo]/r: 643.684 634.664 (μs) 	[μSD μRSD]/r: 17.700μs 2.75%
    benchExecuteParsedQueryWithDeclaredParameterTypeI49 P0 	[μ Mo]/r: 97.673 94.251 (μs) 	[μSD μRSD]/r: 8.259μs 8.46%

2 subjects, 100 iterations, 100 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 88.460 [370.679 364.458] 127.400 (μs)
⅀T: 37,067.880μs μSD/r 12.980μs μRSD/r: 5.603%
suite: 133f0e30090f815142331ebec6af18241694e7c0, date: 2018-12-19, stime: 10:47:10
+------------------------------------+--------------------------------------------------+--------+--------+------+-----+------------+-----------+-----------+-----------+-----------+----------+--------+-------+
| benchmark                          | subject                                          | groups | params | revs | its | mem_peak   | best      | mean      | mode      | worst     | stdev    | rstdev | diff  |
+------------------------------------+--------------------------------------------------+--------+--------+------+-----+------------+-----------+-----------+-----------+-----------+----------+--------+-------+
| QueryBoundParameterProcessingBench | benchExecuteParsedQueryWithInferredParameterType |        | []     | 50   | 50  | 5,970,568b | 604.680μs | 643.684μs | 634.664μs | 677.640μs | 17.700μs | 2.75%  | 6.59x |
| QueryBoundParameterProcessingBench | benchExecuteParsedQueryWithDeclaredParameterType |        | []     | 50   | 50  | 5,922,424b | 88.460μs  | 97.673μs  | 94.251μs  | 127.400μs | 8.259μs  | 8.46%  | 1.00x |
+------------------------------------+--------------------------------------------------+--------+--------+------+-----+------------+-----------+-----------+-----------+-----------+----------+--------+-------+
```

This indicates that the performance impact for NOT declaring parameter types
explicitly is *MASSIVE*.